### PR TITLE
Add ability to hide waystones if they can't be deleted

### DIFF
--- a/common/src/main/java/net/blay09/mods/waystones/api/MutablePersonalizedWaystone.java
+++ b/common/src/main/java/net/blay09/mods/waystones/api/MutablePersonalizedWaystone.java
@@ -10,4 +10,7 @@ public interface MutablePersonalizedWaystone extends PersonalizedWaystone {
     void setAlias(@Nullable Component alias);
 
     void setConfiguredGroups(Collection<ResourceLocation> configuredGroups);
+
+    default void setHidden(boolean hidden) {
+    }
 }

--- a/common/src/main/java/net/blay09/mods/waystones/api/MutablePersonalizedWaystoneDelegate.java
+++ b/common/src/main/java/net/blay09/mods/waystones/api/MutablePersonalizedWaystoneDelegate.java
@@ -29,4 +29,9 @@ public class MutablePersonalizedWaystoneDelegate extends PersonalizedWaystoneDel
     public void setConfiguredGroups(Collection<ResourceLocation> configuredGroups) {
         delegate.setConfiguredGroups(configuredGroups);
     }
+
+    @Override
+    public void setHidden(boolean hidden) {
+        delegate.setHidden(hidden);
+    }
 }

--- a/common/src/main/java/net/blay09/mods/waystones/api/PersonalizedWaystone.java
+++ b/common/src/main/java/net/blay09/mods/waystones/api/PersonalizedWaystone.java
@@ -12,4 +12,8 @@ public interface PersonalizedWaystone extends Waystone {
     Optional<Component> getAlias();
 
     Set<ResourceLocation> getConfiguredGroups();
+
+    default boolean isHidden() {
+        return false;
+    }
 }

--- a/common/src/main/java/net/blay09/mods/waystones/api/PersonalizedWaystoneDelegate.java
+++ b/common/src/main/java/net/blay09/mods/waystones/api/PersonalizedWaystoneDelegate.java
@@ -34,4 +34,9 @@ public class PersonalizedWaystoneDelegate extends WaystoneDelegate implements Pe
     public Set<ResourceLocation> getConfiguredGroups() {
         return delegate.getConfiguredGroups();
     }
+
+    @Override
+    public boolean isHidden() {
+        return delegate.isHidden();
+    }
 }

--- a/common/src/main/java/net/blay09/mods/waystones/client/gui/screen/ManageWaystonesScreen.java
+++ b/common/src/main/java/net/blay09/mods/waystones/client/gui/screen/ManageWaystonesScreen.java
@@ -1,16 +1,16 @@
 package net.blay09.mods.waystones.client.gui.screen;
 
 import net.blay09.mods.balm.api.Balm;
-import net.blay09.mods.waystones.api.Waystone;
-import net.blay09.mods.waystones.api.WaystoneTypes;
-import net.blay09.mods.waystones.api.WaystoneVisibility;
+import net.blay09.mods.waystones.api.*;
 import net.blay09.mods.waystones.client.gui.widget.AbstractWaystoneList;
 import net.blay09.mods.waystones.client.gui.widget.BackToWaystoneSelectionButton;
 import net.blay09.mods.waystones.client.gui.widget.ManageWaystoneGroupsButton;
 import net.blay09.mods.waystones.client.gui.widget.ManageWaystonesList;
 import net.blay09.mods.waystones.core.PlayerWaystoneManager;
+import net.blay09.mods.waystones.core.WaystonePermissionManager;
 import net.blay09.mods.waystones.menu.WaystoneSelectionMenu;
 import net.blay09.mods.waystones.network.message.RemoveWaystoneMessage;
+import net.blay09.mods.waystones.network.message.ServerboundPersonalWaystoneSettingsPacket;
 import net.blay09.mods.waystones.network.message.SortWaystoneMessage;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
@@ -55,13 +55,16 @@ public class ManageWaystonesScreen extends WaystoneSelectionScreenBase {
 
     public boolean canDeleteWaystone(Waystone waystone) {
         final var player = Objects.requireNonNull(Minecraft.getInstance().player);
-        final var isCreative = player.getAbilities().instabuild;
-        if (waystone.getVisibility() == WaystoneVisibility.GLOBAL && !isCreative) {
+        if (waystone.getVisibility() == WaystoneVisibility.GLOBAL
+                && !WaystonePermissionManager.canEveryoneManageGlobalWaystones()
+                && !player.getAbilities().instabuild) {
+            return false;
+        } else if (waystone.getVisibility() == WaystoneVisibility.TEAM && !PlayerWaystoneManager.isWaystoneActivated(player, waystone)) {
             return false;
         }
 
         if (WaystoneTypes.isSharestone(waystone.getWaystoneType())) {
-            if (!isCreative) {
+            if (!player.getAbilities().instabuild) {
                 return false;
             }
         } else if (!waystone.getWaystoneType().equals(WaystoneTypes.WAYSTONE)) {
@@ -69,6 +72,20 @@ public class ManageWaystonesScreen extends WaystoneSelectionScreenBase {
         }
 
         return parent.allowDeletion();
+    }
+
+    public boolean canToggleWaystoneHidden(Waystone waystone) {
+        if (canDeleteWaystone(waystone)) {
+            return false;
+        }
+
+        return WaystoneTypes.isSharestone(waystone.getWaystoneType())
+                || waystone.getVisibility() == WaystoneVisibility.GLOBAL
+                || waystone.getVisibility() == WaystoneVisibility.TEAM;
+    }
+
+    public boolean isWaystoneHidden(Waystone waystone) {
+        return waystone instanceof PersonalizedWaystone personalizedWaystone && personalizedWaystone.isHidden();
     }
 
     public boolean canEditPersonalWaystoneSettings(Waystone waystone) {
@@ -81,6 +98,23 @@ public class ManageWaystonesScreen extends WaystoneSelectionScreenBase {
         removeWaystoneLocally(waystone);
         parent.removeWaystoneLocally(waystone);
         Balm.getNetworking().sendToServer(new RemoveWaystoneMessage(waystone.getWaystoneUid()));
+    }
+
+    public void toggleWaystoneHidden(Waystone waystone) {
+        final var player = Objects.requireNonNull(Minecraft.getInstance().player);
+        final var hidden = !isWaystoneHidden(waystone);
+        if (waystone instanceof MutablePersonalizedWaystone personalizedWaystone) {
+            personalizedWaystone.setHidden(hidden);
+        }
+        PlayerWaystoneManager.setWaystoneHidden(player, waystone.getWaystoneUid(), hidden);
+        parent.updateList();
+        updateList();
+        final var personalizedWaystone = PlayerWaystoneManager.getPlayerDecoratedWaystone(player, waystone);
+        Balm.networking().sendToServer(new ServerboundPersonalWaystoneSettingsPacket(
+                waystone.getWaystoneUid(),
+                personalizedWaystone.getAlias(),
+                personalizedWaystone.getConfiguredGroups(),
+                hidden));
     }
 
     public void openPersonalWaystoneSettings(Waystone waystone) {

--- a/common/src/main/java/net/blay09/mods/waystones/client/gui/screen/PersonalWaystoneSettingsScreen.java
+++ b/common/src/main/java/net/blay09/mods/waystones/client/gui/screen/PersonalWaystoneSettingsScreen.java
@@ -201,7 +201,8 @@ public class PersonalWaystoneSettingsScreen extends WaystoneContainerScreen<Abst
                     .sendToServer(new ServerboundPersonalWaystoneSettingsPacket(
                             waystone.getWaystoneUid(),
                             alias,
-                            selectedGroupIds));
+                            selectedGroupIds,
+                            waystone.isHidden()));
         }
     }
 

--- a/common/src/main/java/net/blay09/mods/waystones/client/gui/screen/WaystoneSelectionScreenBase.java
+++ b/common/src/main/java/net/blay09/mods/waystones/client/gui/screen/WaystoneSelectionScreenBase.java
@@ -3,6 +3,7 @@ package net.blay09.mods.waystones.client.gui.screen;
 import net.blay09.mods.balm.api.Balm;
 import net.blay09.mods.waystones.WaystoneSortMode;
 import net.blay09.mods.waystones.api.MutablePersonalizedWaystone;
+import net.blay09.mods.waystones.api.PersonalizedWaystone;
 import net.blay09.mods.waystones.api.Waystone;
 import net.blay09.mods.waystones.api.WaystoneGroup;
 import net.blay09.mods.waystones.api.WaystoneTypes;
@@ -231,7 +232,11 @@ public abstract class WaystoneSelectionScreenBase extends WaystoneContainerScree
     }
 
     protected boolean shouldShowWaystone(Waystone waystone) {
-        return true;
+        return !isUserHidden(waystone);
+    }
+
+    protected boolean isUserHidden(Waystone waystone) {
+        return waystone instanceof PersonalizedWaystone personalizedWaystone && personalizedWaystone.isHidden();
     }
 
     protected boolean ignoresFilters(Waystone waystone) {

--- a/common/src/main/java/net/blay09/mods/waystones/client/gui/widget/ManageWaystonesList.java
+++ b/common/src/main/java/net/blay09/mods/waystones/client/gui/widget/ManageWaystonesList.java
@@ -166,6 +166,7 @@ public class ManageWaystonesList extends AbstractWaystoneList<ManageWaystonesLis
         private final @Nullable DragHandleButton dragHandleButton;
         private final @Nullable EditWaystoneButton editButton;
         private final @Nullable RemoveWaystoneButton removeButton;
+        private final @Nullable ToggleWaystoneHiddenButton hiddenButton;
 
         public WaystoneEntry(Waystone waystone) {
             this.waystone = waystone;
@@ -202,6 +203,18 @@ public class ManageWaystonesList extends AbstractWaystoneList<ManageWaystonesLis
                 widgets.add(removeButton);
             } else {
                 removeButton = null;
+            }
+
+            if (screen.canToggleWaystoneHidden(waystone)) {
+                hiddenButton = new ToggleWaystoneHiddenButton(0,
+                        0,
+                        ManageWaystonesList.this.getY(),
+                        ManageWaystonesList.this.getHeight(),
+                        () -> screen.isWaystoneHidden(waystone),
+                        button -> screen.toggleWaystoneHidden(waystone));
+                widgets.add(hiddenButton);
+            } else {
+                hiddenButton = null;
             }
         }
 
@@ -248,6 +261,9 @@ public class ManageWaystonesList extends AbstractWaystoneList<ManageWaystonesLis
             }
             if (removeButton != null) {
                 removeButton.setPosition(x + BUTTON_LEFT_OFFSET + BUTTON_WIDTH + MARGIN + EDIT_BUTTON_WIDTH + MARGIN, y + 4);
+            }
+            if (hiddenButton != null) {
+                hiddenButton.setPosition(x + BUTTON_LEFT_OFFSET + BUTTON_WIDTH + MARGIN + EDIT_BUTTON_WIDTH + MARGIN, y + 4);
             }
         }
 

--- a/common/src/main/java/net/blay09/mods/waystones/client/gui/widget/ToggleWaystoneHiddenButton.java
+++ b/common/src/main/java/net/blay09/mods/waystones/client/gui/widget/ToggleWaystoneHiddenButton.java
@@ -1,0 +1,54 @@
+package net.blay09.mods.waystones.client.gui.widget;
+
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.Tooltip;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.function.BooleanSupplier;
+
+import static net.blay09.mods.waystones.Waystones.id;
+
+public class ToggleWaystoneHiddenButton extends Button {
+
+    private static final ResourceLocation VISIBLE_SPRITE = id("widgets/shown");
+    private static final ResourceLocation HIDDEN_SPRITE = id("widgets/hidden");
+
+    private final BooleanSupplier hidden;
+    private final int visibleRegionStart;
+    private final int visibleRegionHeight;
+    private boolean lastHidden;
+
+    public ToggleWaystoneHiddenButton(int x, int y, int visibleRegionStart, int visibleRegionHeight, BooleanSupplier hidden, OnPress pressable) {
+        super(x, y, 18, 18, Component.empty(), pressable, Button.DEFAULT_NARRATION);
+        this.hidden = hidden;
+        this.visibleRegionStart = visibleRegionStart;
+        this.visibleRegionHeight = visibleRegionHeight;
+        lastHidden = hidden.getAsBoolean();
+        updateTooltip();
+    }
+
+    private void updateTooltip() {
+        setTooltip(Tooltip.create(Component.translatable(lastHidden
+                ? "gui.waystones.manage_waystones.show_waystone"
+                : "gui.waystones.manage_waystones.hide_waystone")));
+    }
+
+    @Override
+    public void renderWidget(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTicks) {
+        final var currentHidden = hidden.getAsBoolean();
+        if (currentHidden != lastHidden) {
+            lastHidden = currentHidden;
+            updateTooltip();
+        }
+
+        if (getBottom() > visibleRegionStart && getY() < visibleRegionStart + visibleRegionHeight) {
+            final var sprite = currentHidden ? HIDDEN_SPRITE : VISIBLE_SPRITE;
+            final var alpha = isHovered ? 1f : 0.75f;
+            guiGraphics.setColor(alpha, alpha, alpha, 1f);
+            guiGraphics.blitSprite(sprite, getX(), getY(), 13, 13);
+            guiGraphics.setColor(1f, 1f, 1f, 1f);
+        }
+    }
+}

--- a/common/src/main/java/net/blay09/mods/waystones/core/IPlayerWaystoneData.java
+++ b/common/src/main/java/net/blay09/mods/waystones/core/IPlayerWaystoneData.java
@@ -32,6 +32,8 @@ public interface IPlayerWaystoneData {
     void sortWaystoneGroupSwap(Player player, ResourceLocation groupId, ResourceLocation otherGroupId);
     Set<ResourceLocation> getConfiguredWaystoneGroups(Player player, UUID waystoneUid);
     void setConfiguredWaystoneGroups(Player player, UUID waystoneUid, Set<ResourceLocation> groupIds);
+    boolean isWaystoneHidden(Player player, UUID waystoneUid);
+    void setWaystoneHidden(Player player, UUID waystoneUid, boolean hidden);
     void sortWaystoneAsFirst(Player player, UUID waystoneUid);
     void sortWaystoneAsLast(Player player, UUID waystoneUid);
     void sortWaystoneSwap(Player player, UUID waystoneUid, UUID otherWaystoneUid);

--- a/common/src/main/java/net/blay09/mods/waystones/core/InMemoryPlayerWaystoneData.java
+++ b/common/src/main/java/net/blay09/mods/waystones/core/InMemoryPlayerWaystoneData.java
@@ -18,6 +18,7 @@ public class InMemoryPlayerWaystoneData implements IPlayerWaystoneData {
     private final Map<UUID, Waystone> waystones = new HashMap<>();
     private final Map<ResourceLocation, Long> cooldowns = new HashMap<>();
     private final Map<UUID, Component> aliases = new HashMap<>();
+    private final Set<UUID> hiddenWaystones = new HashSet<>();
     private final SetMultimap<UUID, ResourceLocation> waystoneToConfiguredGroups = MultimapBuilder.hashKeys().hashSetValues().build();
     private final Map<ResourceLocation, WaystoneGroup> groupRegistry = new LinkedHashMap<>();
     private WaystoneSortMode waystoneSortMode = WaystoneSortMode.MANUAL;
@@ -142,6 +143,20 @@ public class InMemoryPlayerWaystoneData implements IPlayerWaystoneData {
     }
 
     @Override
+    public boolean isWaystoneHidden(Player player, UUID waystoneUid) {
+        return hiddenWaystones.contains(waystoneUid);
+    }
+
+    @Override
+    public void setWaystoneHidden(Player player, UUID waystoneUid, boolean hidden) {
+        if (hidden) {
+            hiddenWaystones.add(waystoneUid);
+        } else {
+            hiddenWaystones.remove(waystoneUid);
+        }
+    }
+
+    @Override
     public void sortWaystoneAsFirst(Player player, UUID waystoneUid) {
         sortingIndex.remove(waystoneUid);
         sortingIndex.add(0, waystoneUid);
@@ -200,12 +215,14 @@ public class InMemoryPlayerWaystoneData implements IPlayerWaystoneData {
     public void setWaystones(Player player, Collection<? extends Waystone> waystones) {
         this.waystones.clear();
         aliases.clear();
+        hiddenWaystones.clear();
         waystoneToConfiguredGroups.clear();
         for (final var waystone : waystones) {
             this.waystones.put(waystone.getWaystoneUid(), waystone);
             if (waystone instanceof PersonalizedWaystoneImpl personalizedWaystone) {
                 personalizedWaystone.getAlias().ifPresent(alias -> setWaystoneAlias(player, waystone.getWaystoneUid(), alias));
                 setConfiguredWaystoneGroups(player, personalizedWaystone.getWaystoneUid(), personalizedWaystone.getConfiguredGroups());
+                setWaystoneHidden(player, personalizedWaystone.getWaystoneUid(), personalizedWaystone.isHidden());
             }
         }
     }

--- a/common/src/main/java/net/blay09/mods/waystones/core/PersistentPlayerWaystoneData.java
+++ b/common/src/main/java/net/blay09/mods/waystones/core/PersistentPlayerWaystoneData.java
@@ -23,6 +23,7 @@ public class PersistentPlayerWaystoneData implements IPlayerWaystoneData {
     private static final String COOLDOWNS = "Cooldowns";
     private static final String ALIASES = "Aliases";
     private static final String GROUPS = "Groups";
+    private static final String HIDDEN_WAYSTONES = "HiddenWaystones";
     private static final String GROUP_REGISTRY = "GroupRegistry";
     private static final String GROUP_ID = "Id";
     private static final String GROUP_NAME = "Name";
@@ -193,6 +194,22 @@ public class PersistentPlayerWaystoneData implements IPlayerWaystoneData {
     public void setConfiguredWaystoneGroups(Player player, UUID waystoneUid, Set<ResourceLocation> groupIds) {
         final var groupsByWaystone = getGroupsData(getWaystonesData(player));
         writeGroupIds(groupsByWaystone, waystoneUid, groupIds);
+    }
+
+    @Override
+    public boolean isWaystoneHidden(Player player, UUID waystoneUid) {
+        final var hiddenWaystones = getHiddenWaystonesData(getWaystonesData(player));
+        return hiddenWaystones.getBoolean(waystoneUid.toString());
+    }
+
+    @Override
+    public void setWaystoneHidden(Player player, UUID waystoneUid, boolean hidden) {
+        final var hiddenWaystones = getHiddenWaystonesData(getWaystonesData(player));
+        if (hidden) {
+            hiddenWaystones.putBoolean(waystoneUid.toString(), true);
+        } else {
+            hiddenWaystones.remove(waystoneUid.toString());
+        }
     }
 
     private static void writeGroupIds(CompoundTag groupsByWaystone, UUID waystoneUid, Collection<ResourceLocation> groupIds) {
@@ -399,6 +416,12 @@ public class PersistentPlayerWaystoneData implements IPlayerWaystoneData {
         CompoundTag groups = data.contains(GROUPS, Tag.TAG_COMPOUND) ? data.getCompound(GROUPS) : new CompoundTag();
         data.put(GROUPS, groups);
         return groups;
+    }
+
+    private static CompoundTag getHiddenWaystonesData(CompoundTag data) {
+        CompoundTag hiddenWaystones = data.contains(HIDDEN_WAYSTONES, Tag.TAG_COMPOUND) ? data.getCompound(HIDDEN_WAYSTONES) : new CompoundTag();
+        data.put(HIDDEN_WAYSTONES, hiddenWaystones);
+        return hiddenWaystones;
     }
 
     private static CompoundTag getGroupRegistryData(CompoundTag data) {

--- a/common/src/main/java/net/blay09/mods/waystones/core/PersonalizedWaystoneImpl.java
+++ b/common/src/main/java/net/blay09/mods/waystones/core/PersonalizedWaystoneImpl.java
@@ -29,6 +29,8 @@ public class PersonalizedWaystoneImpl implements MutablePersonalizedWaystone {
             PersonalizedWaystoneImpl::getAlias,
             ByteBufCodecs.collection(ArrayList::new, ResourceLocation.STREAM_CODEC),
             PersonalizedWaystoneImpl::getConfiguredGroups,
+            ByteBufCodecs.BOOL,
+            PersonalizedWaystoneImpl::isHidden,
             PersonalizedWaystoneImpl::new
     );
     public static final StreamCodec<RegistryFriendlyByteBuf, MutablePersonalizedWaystone> DOWNGRADED_STREAM_CODEC = StreamCodec.of(
@@ -40,10 +42,11 @@ public class PersonalizedWaystoneImpl implements MutablePersonalizedWaystone {
     private final Waystone backingWaystone;
     private @Nullable Component alias;
     private Set<ResourceLocation> configuredGroups;
+    private boolean hidden;
 
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-    private PersonalizedWaystoneImpl(Waystone backingWaystone, Optional<Component> alias, Collection<ResourceLocation> configuredGroups) {
-        this(backingWaystone, alias.orElse(null), configuredGroups);
+    private PersonalizedWaystoneImpl(Waystone backingWaystone, Optional<Component> alias, Collection<ResourceLocation> configuredGroups, boolean hidden) {
+        this(backingWaystone, alias.orElse(null), configuredGroups, hidden);
     }
 
     public PersonalizedWaystoneImpl(Waystone backingWaystone, @Nullable Component alias) {
@@ -51,15 +54,20 @@ public class PersonalizedWaystoneImpl implements MutablePersonalizedWaystone {
     }
 
     public PersonalizedWaystoneImpl(Waystone backingWaystone, @Nullable Component alias, Collection<ResourceLocation> configuredGroups) {
+        this(backingWaystone, alias, configuredGroups, false);
+    }
+
+    public PersonalizedWaystoneImpl(Waystone backingWaystone, @Nullable Component alias, Collection<ResourceLocation> configuredGroups, boolean hidden) {
         this.backingWaystone = backingWaystone;
         this.alias = alias;
         this.configuredGroups = Set.copyOf(configuredGroups);
+        this.hidden = hidden;
     }
 
     public static PersonalizedWaystoneImpl from(PersonalizedWaystone waystone) {
         return waystone instanceof PersonalizedWaystoneImpl personalizedWaystone
                 ? personalizedWaystone
-                : new PersonalizedWaystoneImpl(waystone.getBackingWaystone(), waystone.getAlias().orElse(null), waystone.getConfiguredGroups());
+                : new PersonalizedWaystoneImpl(waystone.getBackingWaystone(), waystone.getAlias().orElse(null), waystone.getConfiguredGroups(), waystone.isHidden());
     }
 
     public Waystone getBackingWaystone() {
@@ -82,6 +90,16 @@ public class PersonalizedWaystoneImpl implements MutablePersonalizedWaystone {
     @Override
     public void setConfiguredGroups(Collection<ResourceLocation> configuredGroups) {
         this.configuredGroups = Set.copyOf(configuredGroups);
+    }
+
+    @Override
+    public boolean isHidden() {
+        return hidden;
+    }
+
+    @Override
+    public void setHidden(boolean hidden) {
+        this.hidden = hidden;
     }
 
     @Override

--- a/common/src/main/java/net/blay09/mods/waystones/core/PlayerWaystoneManager.java
+++ b/common/src/main/java/net/blay09/mods/waystones/core/PlayerWaystoneManager.java
@@ -188,6 +188,14 @@ public class PlayerWaystoneManager {
         getPlayerWaystoneData(player.level()).setConfiguredWaystoneGroups(player, waystoneUid, groupIds);
     }
 
+    public static boolean isWaystoneHidden(Player player, Waystone waystone) {
+        return getPlayerWaystoneData(player.level()).isWaystoneHidden(player, waystone.getWaystoneUid());
+    }
+
+    public static void setWaystoneHidden(Player player, UUID waystoneUid, boolean hidden) {
+        getPlayerWaystoneData(player.level()).setWaystoneHidden(player, waystoneUid, hidden);
+    }
+
     public static void ensureWaystoneGroups(Player player, Waystone waystone) {
         ensureWaystoneGroups(player, WaystoneGroups.getDynamicGroupDefinitions(waystone));
     }
@@ -208,7 +216,8 @@ public class PlayerWaystoneManager {
         final var backingWaystone = waystone instanceof PersonalizedWaystoneImpl personalizedWaystone ? personalizedWaystone.getBackingWaystone() : waystone;
         final var alias = getWaystoneAlias(player, backingWaystone.getWaystoneUid());
         final var configuredWaystoneGroups = getConfiguredWaystoneGroups(player, backingWaystone.getWaystoneUid());
-        return new PersonalizedWaystoneImpl(backingWaystone, alias.orElse(null), configuredWaystoneGroups);
+        final var hidden = getPlayerWaystoneData(player.level()).isWaystoneHidden(player, backingWaystone.getWaystoneUid());
+        return new PersonalizedWaystoneImpl(backingWaystone, alias.orElse(null), configuredWaystoneGroups, hidden);
     }
 
     public static List<PersonalizedWaystoneImpl> getPlayerDecoratedWaystones(Player player, Collection<Waystone> waystones) {

--- a/common/src/main/java/net/blay09/mods/waystones/core/WaystonePermissionManager.java
+++ b/common/src/main/java/net/blay09/mods/waystones/core/WaystonePermissionManager.java
@@ -64,7 +64,7 @@ public class WaystonePermissionManager {
     }
 
     @SuppressWarnings("deprecation")
-    private static boolean canEveryoneManageGlobalWaystones() {
+    public static boolean canEveryoneManageGlobalWaystones() {
         final var config = WaystonesConfig.getActive();
         return config.general.allowEveryoneToManageGlobalWaystones
                 || config.general.defaultVisibility.asWaystoneVisibility() == WaystoneVisibility.GLOBAL

--- a/common/src/main/java/net/blay09/mods/waystones/core/WaystoneUserSettings.java
+++ b/common/src/main/java/net/blay09/mods/waystones/core/WaystoneUserSettings.java
@@ -1,4 +1,0 @@
-package net.blay09.mods.waystones.core;
-
-public record WaystoneUserSettings(WaystoneUserVisibility visibility) {
-}

--- a/common/src/main/java/net/blay09/mods/waystones/core/WaystoneUserVisibility.java
+++ b/common/src/main/java/net/blay09/mods/waystones/core/WaystoneUserVisibility.java
@@ -1,7 +1,0 @@
-package net.blay09.mods.waystones.core;
-
-public enum WaystoneUserVisibility {
-    DEFAULT,
-    FAVORITE,
-    HIDDEN
-}

--- a/common/src/main/java/net/blay09/mods/waystones/network/ModNetworking.java
+++ b/common/src/main/java/net/blay09/mods/waystones/network/ModNetworking.java
@@ -9,7 +9,7 @@ import net.blay09.mods.waystones.network.message.*;
 public class ModNetworking {
 
     public static void initialize(BalmNetworking networking) {
-        networking.defineNetworkVersion(Waystones.MOD_ID, "3");
+        networking.defineNetworkVersion(Waystones.MOD_ID, "4");
 
         networking.registerServerboundPacket(InventoryButtonMessage.TYPE, InventoryButtonMessage.class, InventoryButtonMessage::encode, InventoryButtonMessage::decode, InventoryButtonMessage::handle);
         networking.registerServerboundPacket(EditWaystoneMessage.TYPE, EditWaystoneMessage.class, EditWaystoneMessage::encode, EditWaystoneMessage::decode, EditWaystoneMessage::handle);

--- a/common/src/main/java/net/blay09/mods/waystones/network/message/ServerboundPersonalWaystoneSettingsPacket.java
+++ b/common/src/main/java/net/blay09/mods/waystones/network/message/ServerboundPersonalWaystoneSettingsPacket.java
@@ -5,6 +5,7 @@ import net.blay09.mods.waystones.Waystones;
 import net.blay09.mods.waystones.core.PlayerWaystoneManager;
 import net.blay09.mods.waystones.core.PersonalizedWaystoneImpl;
 import net.blay09.mods.waystones.core.WaystoneSyncManager;
+import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.ComponentSerialization;
@@ -26,27 +27,35 @@ public class ServerboundPersonalWaystoneSettingsPacket implements CustomPacketPa
     private final UUID waystoneUid;
     private final Optional<Component> alias;
     private final Set<ResourceLocation> groupIds;
+    private final boolean hidden;
 
     public ServerboundPersonalWaystoneSettingsPacket(UUID waystoneUid, Optional<Component> alias) {
-        this(waystoneUid, alias, Set.of());
+        this(waystoneUid, alias, Set.of(), false);
     }
 
     public ServerboundPersonalWaystoneSettingsPacket(UUID waystoneUid, Optional<Component> alias, Set<ResourceLocation> groupIds) {
+        this(waystoneUid, alias, groupIds, false);
+    }
+
+    public ServerboundPersonalWaystoneSettingsPacket(UUID waystoneUid, Optional<Component> alias, Set<ResourceLocation> groupIds, boolean hidden) {
         this.waystoneUid = waystoneUid;
         this.alias = alias;
         this.groupIds = groupIds;
+        this.hidden = hidden;
     }
 
     public static void encode(RegistryFriendlyByteBuf buf, ServerboundPersonalWaystoneSettingsPacket message) {
         buf.writeUUID(message.waystoneUid);
         ComponentSerialization.OPTIONAL_STREAM_CODEC.encode(buf, message.alias);
-        buf.writeCollection(message.groupIds, (innerBuf, groupId) -> innerBuf.writeResourceLocation(groupId));
+        buf.writeCollection(message.groupIds, FriendlyByteBuf::writeResourceLocation);
+        buf.writeBoolean(message.hidden);
     }
 
     public static ServerboundPersonalWaystoneSettingsPacket decode(RegistryFriendlyByteBuf buf) {
         return new ServerboundPersonalWaystoneSettingsPacket(buf.readUUID(),
                 ComponentSerialization.OPTIONAL_STREAM_CODEC.decode(buf),
-                buf.readCollection(HashSet::new, innerBuf -> innerBuf.readResourceLocation()));
+                buf.readCollection(HashSet::new, FriendlyByteBuf::readResourceLocation),
+                buf.readBoolean());
     }
 
     public static void handle(ServerPlayer player, ServerboundPersonalWaystoneSettingsPacket message) {
@@ -59,9 +68,10 @@ public class ServerboundPersonalWaystoneSettingsPacket implements CustomPacketPa
         final var resolvedWaystone = waystone.get();
         PlayerWaystoneManager.setWaystoneAlias(player, resolvedWaystone.getWaystoneUid(), message.alias.orElse(null));
         PlayerWaystoneManager.setConfiguredWaystoneGroups(player, resolvedWaystone.getWaystoneUid(), message.groupIds);
+        PlayerWaystoneManager.setWaystoneHidden(player, resolvedWaystone.getWaystoneUid(), message.hidden);
         WaystoneSyncManager.sendActivatedWaystones(player);
         if (resolvedWaystone.isTransient()) {
-            Balm.getNetworking().sendTo(player, new UpdateWaystoneMessage(new PersonalizedWaystoneImpl(resolvedWaystone, message.alias.orElse(null), message.groupIds)));
+            Balm.networking().sendTo(player, new UpdateWaystoneMessage(new PersonalizedWaystoneImpl(resolvedWaystone, message.alias.orElse(null), message.groupIds, message.hidden)));
         }
     }
 

--- a/common/src/main/resources/assets/waystones/lang/en_us.json
+++ b/common/src/main/resources/assets/waystones/lang/en_us.json
@@ -66,6 +66,8 @@
   "container.waystones.manage_groups": "Manage Groups",
   "container.waystones.edit_group": "Edit Group",
   "gui.waystones.manage_waystones.drag_to_reorder": "Drag to reorder. Double-click to move to top. Shift-double-click to move to bottom.",
+  "gui.waystones.manage_waystones.hide_waystone": "Hide Waystone",
+  "gui.waystones.manage_waystones.show_waystone": "Show Waystone",
   "gui.waystones.manage_groups.no_groups": "There are no groups available.",
   "gui.waystones.manage_groups.create": "Create Group",
   "gui.waystones.manage_groups.hide_group": "Hide Inbuilt Group",


### PR DESCRIPTION
Works the same as hiding inbuilt groups.

Applies to
- global waystones
- team waystones that have not been activated
- sharestones

#1222