### PR TITLE
fix: NPE in CombinedRequirementRenderer.renderWidget for requirements with no renderer

### DIFF
--- a/common/src/main/java/net/blay09/mods/waystones/client/requirement/CombinedRequirementRenderer.java
+++ b/common/src/main/java/net/blay09/mods/waystones/client/requirement/CombinedRequirementRenderer.java
@@ -14,6 +14,7 @@ public class CombinedRequirementRenderer implements RequirementRenderer<Combined
                 .stream()
                 .filter(it -> !it.isEmpty())
                 .map(it -> Pair.of(it, RequirementClientRegistry.getRenderer(it)))
+                .filter(it -> it.getSecond() != null)
                 .sorted(Comparator.comparingInt(it -> it.getSecond().getOrder()))
                 .toList();
         var currentX = x;


### PR DESCRIPTION
### Problem

Opening the waystone selection screen crashes the client with a `NullPointerException` when a waystone's requirement chain contains a requirement type that has **no registered client renderer** — reproducible with the built-in `dismount` requirement modifier.

`CombinedRequirementRenderer.renderWidget` sorts child requirements by their renderer's order without null-checking the renderer:

```java
.map(it -> Pair.of(it, RequirementClientRegistry.getRenderer(it)))
.sorted(Comparator.comparingInt(it -> it.getSecond().getOrder())) // getSecond() may be null
```

`RequirementClientRegistry.getRenderer(...)` returns `null` for `DismountRequirement` (it's never registered in `registerDefaults()`), and `DismountRequirement` inherits the default `isEmpty() == false`, so it survives the `!isEmpty()` filter and reaches the sort, where the comparator dereferences the null renderer.

```
java.lang.NullPointerException: Cannot invoke
"net.blay09.mods.waystones.client.requirement.RequirementRenderer.getOrder()"
because the return value of "com.mojang.datafixers.util.Pair.getSecond()" is null
    at ...CombinedRequirementRenderer.lambda$renderWidget$2(CombinedRequirementRenderer.java:17)
    at java.base/java.util.TimSort.sort(...)
    at ...CombinedRequirementRenderer.renderWidget(CombinedRequirementRenderer.java:18)
    at ...WaystoneButton.renderRequirements(WaystoneButton.java:63)
Screen name: net.blay09.mods.waystones.client.gui.screen.WaystoneSelectionScreen
```

### Fix

Add the same null guard that `getWidth()` already has before the sort. This completes commit `9dde8b40` ("fix: Fix crash on requirements that have no renderer attached"), which added `.filter(it -> it.getSecond() != null)` to `getWidth()` but missed the identical code path in `renderWidget()`.

```java
.map(it -> Pair.of(it, RequirementClientRegistry.getRenderer(it)))
.filter(it -> it.getSecond() != null)
.sorted(Comparator.comparingInt(it -> it.getSecond().getOrder()))
.toList();
```

Using `.filter` here (rather than the ternary guard used on the rewritten `26.2` branch) keeps `renderWidget()` structurally identical to the adjacent `getWidth()` on this branch.

### Notes

- This targets the `1.21.1` branch. On `26.2` the file was rewritten and `renderWidget` already guards the null (`it.getSecond() != null ? it.getSecond().getOrder() : 100`), so the crash does not occur there — this is a backport of that protection to the 1.21.1 line.
- Affects 21.1.39–21.1.41 (all contain the incomplete `9dde8b40` fix).

### Testing

- Reproduced the crash on 21.1.41 with a `dismount` requirement configured; confirmed the fix resolves it.
